### PR TITLE
Works on file://* in Chrome

### DIFF
--- a/LiveReload.chromeextension/manifest.json
+++ b/LiveReload.chromeextension/manifest.json
@@ -4,7 +4,7 @@
   "background_page": "background.html",
   "content_scripts": [
     {
-      "matches": ["http://*/*"],
+      "matches": ["http://*/*", "file://*/*"],
       "js": ["LiveReload-content.js"]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Limitations
 
 Note that you can only have one page monitored, so if you enable LiveReload on another page, the first one will stop reloading.
 
-LiveReload does not work with local files in Chrome (since accessing file:// URLs from an extension requires an approval from the Google Chrome team) and in Safari (since we haven't bothered fixing it yet).
+LiveReload does not work with local files in Safari (since we haven't bothered fixing it yet).
 
 
 License


### PR DESCRIPTION
Currently, neither the Chrome extensions nor the Safari extension work on `file://`. I dunno about Safari, but I fixed it for the Chrome extension.

![file scheme](http://elv1s.ru/i/livereload-file-scheme-acce.png)  
_You have to check this checkbox_

By the way, it's not easy to publish an extension with file permissions. You have to go through a manual review and then sight some paper (they will send email, you'll have to print it), then scan it, and then mail it back (or fax it, lol).
