### PR TITLE
apply_js_live=false by default

### DIFF
--- a/server/lib/livereload.rb
+++ b/server/lib/livereload.rb
@@ -118,7 +118,7 @@ module LiveReload
     config.port  = 35729
     config.exts  = %w/html css js png gif jpg php php5 py rb erb/
     config.exclusions = %w!*/.git/* */.svn/* */.hg/*!
-    config.apply_js_live  = true
+    config.apply_js_live  = false
     config.apply_css_live = true
     config.grace_period = 0.05
   end


### PR DESCRIPTION
When apply_js_live happens it neither erase all old variables nor restore DOM changes. It doesn't work well in pretty much all cases. Why don't we turn it off by default?
