### PR TITLE
Firefox extension: options dialog

### DIFF
--- a/Firefox/content/background-firefox.js
+++ b/Firefox/content/background-firefox.js
@@ -4,6 +4,24 @@ LivereloadBackgroundFirefox.prototype = new LivereloadBackground(function reload
     client.reload(data);
 });
 
+LivereloadBackgroundFirefox.prototype.connect = function () {
+	var self = this;
+
+	this.prefs = Components.classes["@mozilla.org/preferences-service;1"]
+         .getService(Components.interfaces.nsIPrefService)
+         .getBranch("livereload.");
+    this.prefs.QueryInterface(Components.interfaces.nsIPrefBranch2);
+    this.prefs.addObserver("", {observe: function () {
+        self.disconnect();
+    }}, false);
+
+    this.host = this.prefs.getCharPref("host");
+
+    this.port = this.prefs.getIntPref("port");
+
+    this.__proto__.__proto__.connect.call(this);
+};
+
 LivereloadBackgroundFirefox.prototype.sendPageUrl = function() {
     var activeTab = this.lastPage;
     if (activeTab == null) {

--- a/Firefox/content/options.xul
+++ b/Firefox/content/options.xul
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+ 
+<prefwindow id="livereload-prefs"
+     title="LiveReload Options"
+     xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+ 
+<prefpane id="lr-options-pane" label="LiveReload Settings">
+  <preferences>
+    <preference id="pref_host" name="livereload.host" type="string"/>
+    <preference id="pref_port" name="livereload.port" type="int"/>
+  </preferences>
+  
+  <vbox>
+    <hbox align="center">
+      <label control="symbol" value="Host: "/>
+      <textbox preference="pref_host" id="host"/>
+    </hbox>
+    <hbox align="center">
+      <label control="symbol" value="Port: "/>
+      <textbox preference="pref_port" id="port" maxlength="5"/>
+    </hbox>
+  </vbox>
+</prefpane>
+ 
+</prefwindow>

--- a/Firefox/defaults/preferences/defaults.js
+++ b/Firefox/defaults/preferences/defaults.js
@@ -1,0 +1,2 @@
+pref("livereload.host", "localhost");
+pref("livereload.port", 35729);

--- a/Firefox/install.rdf
+++ b/Firefox/install.rdf
@@ -10,6 +10,7 @@
     <em:contributor>Andrey Tarantsov</em:contributor>
     <em:homepageURL>http://livereload.com/</em:homepageURL>
     <em:iconURL>chrome://livereload/skin/icon_32.png</em:iconURL>
+    <em:optionsURL>chrome://livereload/content/options.xul</em:optionsURL>	
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->


### PR DESCRIPTION
Adds a simple options dialog to the Firefox extension for setting host and port.
