### PR TITLE
Playframework SASS module support

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -514,6 +514,8 @@ LivereloadContent.prototype = {
 
 LivereloadContent.prototype['.js'] = LivereloadContent.prototype.handleJS;
 LivereloadContent.prototype['.css'] = LivereloadContent.prototype.handleCSS;
+LivereloadContent.prototype['.sass'] = LivereloadContent.prototype.handleCSS;
+LivereloadContent.prototype['.scss'] = LivereloadContent.prototype.handleCSS;
 LivereloadContent.prototype['.jpg'] =
 LivereloadContent.prototype['.jpeg'] =
 LivereloadContent.prototype['.png'] =


### PR DESCRIPTION
Added two lines to allow livereload to live reload changes from scss and ass files generated by playframework's sass module (http://www.playframework.org/modules/sass)
- These two modules compiles the .sass and .scss files on the fly before sending valid vanilla css out to the browser. However the extensions used in html files to include those _special_ css files are sass and scss. 

If there is no conflict this could be an interesting addition to people using playframework
