### PR TITLE
Firefox extension : converting the LiveReload’s status icon to a toolbar button.

### DIFF
--- a/Firefox/content/background-firefox.js
+++ b/Firefox/content/background-firefox.js
@@ -32,12 +32,12 @@ LivereloadBackgroundFirefox.prototype.sendPageUrl = function() {
 };
 
 LivereloadBackgroundFirefox.prototype.onEnablePage = function(tabId) {
-    this.icon.src = 'chrome://livereload/skin/icon_16-on.png';
+    this.icon.image = 'chrome://livereload/skin/icon_16-on.png';
     this.icon.setAttribute('tooltiptext', 'Disable LiveReload');
 };
 
 LivereloadBackgroundFirefox.prototype.onDisablePage = function(tabId) {
-    this.icon.src = 'chrome://livereload/skin/icon_16-off.png';
+    this.icon.image = 'chrome://livereload/skin/icon_16-off.png';
     this.icon.setAttribute('tooltiptext', 'Enable LiveReload');
 };
 
@@ -47,7 +47,7 @@ window.addEventListener('load', function() {
     var livereloadBackground = new LivereloadBackgroundFirefox;
     //@debug window.livereloadBackground = livereloadBackground;
 
-    var icon = livereloadBackground.icon = document.getElementById('livereload-icon');
+    var icon = livereloadBackground.icon = document.getElementById('livereload-button');
 
     icon.addEventListener('command', function(event) {
         livereloadBackground.togglePage(event.view.gBrowser.selectedTab);

--- a/Firefox/content/browser.xul
+++ b/Firefox/content/browser.xul
@@ -6,7 +6,7 @@
   <script src="background.js"/>
   <script src="background-firefox.js"/>
 
-  <statusbar id="status-bar">
-    <statusbarpanel id="livereload-icon" class="statusbarpanel-iconic" tooltiptext="Enable LiveReload" src="chrome://livereload/skin/icon_16-off.png" label="LR"/>
-  </statusbar>
+  <toolbarpalette id="BrowserToolbarPalette">
+    <toolbarbutton id="livereload-button" label="LR" tooltiptext="Enable LiveReload" image="chrome://livereload/skin/icon_16-off.png" style="-moz-image-region: rect(0, 16px, 16px, 0);"/>
+  </toolbarpalette>
 </overlay>

--- a/Firefox/content/browser.xul
+++ b/Firefox/content/browser.xul
@@ -7,6 +7,6 @@
   <script src="background-firefox.js"/>
 
   <toolbarpalette id="BrowserToolbarPalette">
-    <toolbarbutton id="livereload-button" label="LR" tooltiptext="Enable LiveReload" image="chrome://livereload/skin/icon_16-off.png" style="-moz-image-region: rect(0, 16px, 16px, 0);"/>
+    <toolbarbutton id="livereload-button" label="LR" tooltiptext="Enable LiveReload" image="chrome://livereload/skin/icon_16-off.png"  type="button" class="toolbarbutton-1 chromeclass-toolbar-additional" style="-moz-image-region: rect(0, 16px, 16px, 0);"/>
   </toolbarpalette>
 </overlay>


### PR DESCRIPTION
Here are the few changes to make this button movable from the Firefox’s palette toolbar.
I have made them for a while now, but never took time to push them.
So I decided to do it as soon as I saw the issue #85 from @pjg.

If you can’t wait for the new version to be available on Mozilla’s add-ons site, just apply these changes directly to your installed extension or rebuild it with the `rake firefox` task from your repo directory.
It works well for me with Guard.

Hope it helps and it could be usefull ;o)
(sorry I’m too low on battery to find if it’s possible to link this pull-request with the #85 issue directly ??!!?!)
