### PR TITLE
Fix for Issue #80 and Issue #84 - Replace 'ruby-json' with 'json'

### DIFF
--- a/server/lib/livereload.rb
+++ b/server/lib/livereload.rb
@@ -1,6 +1,6 @@
 require 'em-websocket'
 require 'em-dir-watcher'
-require 'json/objects'
+require 'json'
 require 'stringio'
 
 # Chrome sometimes sends HTTP/1.0 requests in violation of WebSockets spec

--- a/server/livereload.gemspec
+++ b/server/livereload.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
    s.requirements << 'LiveReload Safari extension'
    s.add_dependency('em-websocket', '>= 0.2.1')
    s.add_dependency('em-dir-watcher', '>= 0.1')
-   s.add_dependency('ruby-json', '>= 1.1.2')
+   s.add_dependency('json', '>= 1.5.3')
 end


### PR DESCRIPTION
Tested on Rails 3.0.9 with Chrome extension, appears to work as expected.
